### PR TITLE
Update versions.tf to support 1.x of terraform

### DIFF
--- a/common_components/orchestration/infrastructure/versions.tf
+++ b/common_components/orchestration/infrastructure/versions.tf
@@ -14,5 +14,5 @@
 
 
 terraform {
-  required_version = "~> 1.2.0"
+  required_version = "~> 1.2"
 }


### PR DESCRIPTION
Now that 1.3 is available, we should support any version of terraform with a major version of 1. This change enables that.

Details of version constraints are here:
https://developer.hashicorp.com/terraform/language/expressions/version-constraints