### PR TITLE
Correct typo in the dataset name

### DIFF
--- a/common_components/orchestration/infrastructure/terraform.tfvars.template
+++ b/common_components/orchestration/infrastructure/terraform.tfvars.template
@@ -15,7 +15,7 @@
 project="PROJECT_ID"
 bq_datasets=[
   "regrep_source", 
-  "reg_rep"
+  "regrep"
 ]
 region="REGION"
 bq_location="BQ_LOCATION"


### PR DESCRIPTION
Correcting a typo in the dataset name, it should be `regrep` and not `reg_rep`