### PR TITLE
Create module for creating dbt_log operational dashboard

### DIFF
--- a/common_components/monitoring/module/dbt_dashboard.sql
+++ b/common_components/monitoring/module/dbt_dashboard.sql
@@ -1,0 +1,86 @@
+-- Copyright 2023 The Reg Reporting Blueprint Authors
+
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+
+--     https://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
+-- DBT Dashboard
+--
+-- Create a view with useful metrics for an operational view of the DBT executions
+-- in Airflow.
+
+SELECT
+  * EXCEPT (json_timings),
+
+  -- Timing information (for job)
+  (
+    SELECT AS STRUCT
+      MIN(PARSE_DATETIME("%Y-%m-%dT%H:%M:%E*S", JSON_EXTRACT_SCALAR(t, "$.completed_at"))) AS completed_at,
+      MIN(PARSE_DATETIME("%Y-%m-%dT%H:%M:%E*S", JSON_EXTRACT_SCALAR(t, "$.started_at"))) AS started_at
+    FROM
+      UNNEST(json_timings) t
+    WHERE
+      JSON_EXTRACT_SCALAR(t, "$.name")="compile"
+  ) AS compile_timing,
+  (
+    SELECT AS STRUCT
+      MIN(PARSE_DATETIME("%Y-%m-%dT%H:%M:%E*S", JSON_EXTRACT_SCALAR(t, "$.completed_at"))) AS completed_at,
+      MIN(PARSE_DATETIME("%Y-%m-%dT%H:%M:%E*S", JSON_EXTRACT_SCALAR(t, "$.started_at"))) AS started_at
+    FROM
+      UNNEST(json_timings) t
+    WHERE
+      JSON_EXTRACT_SCALAR(t, "$.name")="compile"
+  ) AS execute_timing,
+
+  -- NOTE: This only works if source_ref is a valid identifier, which normally
+  -- requires a CI/CD triggered build from source.
+  --
+  -- Source
+  CONCAT('${src_url}/',
+    build_info.source_ref, '/', build_info.source_path)
+    AS github_link,
+
+  -- Building
+  CONCAT('https://console.cloud.google.com/cloud-build/builds;region=global/',
+    build_info.build_ref, '?project=${project_id}')
+    AS build_link,
+
+  -- Docs
+  CONCAT("https://storage.cloud.google.com/${docs_bucket}/build/",
+    build_info.build_ref, '/static_index.html')
+    AS doc_link,
+
+  -- Airflow
+  CONCAT('${airflow_url}/graph?dag_id=',
+    airflow_info.airflow_dag_id, '&execution_date=', airflow_info.airflow_execution_date)
+    AS airflow_dag_link,
+  CONCAT('${airflow_url}/log?dag_id=',
+    airflow_info.airflow_dag_id, '&task_id=', airflow_info.airflow_task_id,
+    '&execution_date=', airflow_info.airflow_execution_date)
+    AS airflow_task_link,
+  CONCAT('${airflow_url}/task?dag_id=',
+    airflow_info.airflow_dag_id, '&task_id=', airflow_info.airflow_task_id,
+    '&execution_date=', airflow_info.airflow_execution_date)
+    AS airflow_task_info_link,
+
+  -- Job information
+  CONCAT('https://console.cloud.google.com/bigquery?project=', response_bigquery.project_id,
+         '&j=bq:', response_bigquery.location, ':', response_bigquery.job_id, '&page=queryresults') AS job_link
+
+FROM
+  `${monitoring_dataset}.dbt_start`
+  JOIN `${monitoring_dataset}.dbt_end` USING (dbt_invocation_id)
+WHERE
+  response_bigquery.job_id IS NOT NULL AND
+  airflow_info.airflow_dag_id IS NOT NULL
+ORDER BY
+  start_time DESC

--- a/common_components/monitoring/module/dbt_end.sql
+++ b/common_components/monitoring/module/dbt_end.sql
@@ -1,0 +1,47 @@
+-- Copyright 2022 The Reg Reporting Blueprint Authors
+
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+
+--     https://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
+-- DBT logging END stage processing
+--
+-- Create a materialized view of extracted JSON fields for the END stage of processing
+
+SELECT
+  update_time AS end_time,
+  dbt_invocation_id,
+
+  -- Specific node for the result from BigQuery
+  JSON_EXTRACT_SCALAR(results, "$.id") AS id,
+
+  -- BigQuery specific information
+  STRUCT(
+    JSON_EXTRACT_SCALAR(results, "$.adapter_response._message") AS message,
+    CAST(JSON_EXTRACT_SCALAR(results, "$.adapter_response.bytes_processed") AS INT64) AS bytes_processed,
+    JSON_EXTRACT_SCALAR(results, "$.adapter_response.code") AS code,
+    JSON_EXTRACT_SCALAR(results, "$.adapter_response.job_id") AS job_id,
+    JSON_EXTRACT_SCALAR(results, "$.adapter_response.location") AS location,
+    JSON_EXTRACT_SCALAR(results, "$.adapter_response.project_id") AS project_id,
+    CAST(JSON_EXTRACT_SCALAR(results, "$.adapter_response.rows_affected") AS INT64) AS rows_affected,
+    CAST(JSON_EXTRACT_SCALAR(results, "$.adapter_response.slot_ms") AS FLOAT64) AS slot_ms
+  ) AS response_bigquery,
+
+  -- DBT timings information
+  JSON_EXTRACT_ARRAY(results, "$.timing") json_timings
+ 
+FROM
+  `${monitoring_dataset}.dbt_log` l
+  CROSS JOIN UNNEST(JSON_EXTRACT_ARRAY(l.info)) AS results
+WHERE
+  stage='END' AND
+  JSON_EXTRACT_SCALAR(results, "$.id") NOT LIKE '%test%'

--- a/common_components/monitoring/module/dbt_log_schema.json
+++ b/common_components/monitoring/module/dbt_log_schema.json
@@ -1,0 +1,18 @@
+[
+    {
+        "name": "update_time",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "dbt_invocation_id",
+        "type": "STRING"
+    },
+    {
+        "name": "stage",
+        "type": "STRING"
+    },
+    {
+        "name": "info",
+        "type": "JSON"
+    }
+]

--- a/common_components/monitoring/module/dbt_start.sql
+++ b/common_components/monitoring/module/dbt_start.sql
@@ -1,0 +1,54 @@
+-- Copyright 2023 The Reg Reporting Blueprint Authors
+
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+
+--     https://www.apache.org/licenses/LICENSE-2.0
+
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
+-- DBT Log START stage processing
+--
+-- Create a materialized view of JSON extracted fields for the START stage of
+-- processing.
+
+SELECT
+  update_time AS start_time,
+  dbt_invocation_id,
+
+  -- DBT project
+  JSON_EXTRACT_SCALAR(info, "$.project") AS project,
+
+  -- Profile information (how to execute on BigQuery)
+  STRUCT(
+    JSON_EXTRACT_SCALAR(info, "$.target.database") AS data_project_id,
+    JSON_EXTRACT_SCALAR(info, "$.target.dataset") AS data_dataset,
+    JSON_EXTRACT_SCALAR(info, "$.target.execution_project") AS execution_project_id,
+    JSON_EXTRACT_SCALAR(info, "$.target.location") AS data_location,
+    JSON_EXTRACT_SCALAR(info, "$.target.project") AS project_id
+  ) AS target_bigquery,
+
+  -- Source and build information
+  STRUCT(
+    NULLIF(JSON_EXTRACT_SCALAR(info, "$.vars.source_path"), "unset") AS source_path,
+    NULLIF(JSON_EXTRACT_SCALAR(info, "$.vars.source_ref"), "unset") AS source_ref,
+    NULLIF(JSON_EXTRACT_SCALAR(info, "$.vars.build_ref"), "unset") AS build_ref
+  ) AS build_info,
+
+  -- Airflow execution information
+  STRUCT(
+    NULLIF(JSON_EXTRACT_SCALAR(info, "$.vars.airflow_task_id"), "unset") AS airflow_task_id,
+    NULLIF(JSON_EXTRACT_SCALAR(info, "$.vars.airflow_dag_id"), "unset") AS airflow_dag_id,
+    NULLIF(JSON_EXTRACT_SCALAR(info, "$.vars.airflow_execution_date"), "unset") AS airflow_execution_date
+  ) AS airflow_info
+
+FROM
+  `${monitoring_dataset}.dbt_log`
+WHERE
+  stage='START'

--- a/common_components/monitoring/module/main.tf
+++ b/common_components/monitoring/module/main.tf
@@ -1,0 +1,162 @@
+# Copyright 2023 The Reg Reporting Blueprint Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Create dataset for monitoring
+module "bigquery_monitoring" {
+  source = "github.com/terraform-google-modules/terraform-google-bigquery?ref=v6.1.1"
+
+  project_id   = var.project_id
+  dataset_id   = each.value
+  dataset_name = each.value
+  description  = "Dataset ${each.value} created by terraform"
+  location     = var.bq_location
+
+  # List of datasets to create
+  for_each = toset([var.monitoring_dataset])
+}
+
+
+# Create dbt_log table outline.
+resource "google_bigquery_table" "dbt_log_table" {
+
+  # Only create table after the dataset is created
+  depends_on = [
+    module.bigquery_monitoring
+  ]
+
+  dataset_id    = var.monitoring_dataset
+  table_id      = "dbt_log"
+  friendly_name = "dbt_log"
+  project       = var.project_id
+
+  labels              = {}
+  schema              = file("${path.module}/dbt_log_schema.json")
+  deletion_protection = false
+
+  time_partitioning {
+    type                     = "DAY"
+    expiration_ms            = null
+    field                    = "update_time"
+    require_partition_filter = false
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # managed by google_bigquery_dataset.main.default_encryption_configuration
+      encryption_configuration
+    ]
+  }
+}
+
+data "template_file" "dbt_start" {
+  template = file("${path.module}/dbt_start.sql")
+  vars = {
+    monitoring_dataset = var.monitoring_dataset
+  }
+}
+
+# Create dbt_end materialized view
+resource "google_bigquery_table" "dbt_start" {
+  project             = var.project_id
+  dataset_id          = var.monitoring_dataset
+  friendly_name       = "dbt_start"
+  table_id            = "dbt_start"
+  description         = "DBT start stage extraction"
+  deletion_protection = false
+
+  materialized_view {
+    query = data.template_file.dbt_start.rendered
+  }
+
+  depends_on = [
+    google_bigquery_table.dbt_log_table
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      encryption_configuration
+    ]
+  }
+}
+
+data "template_file" "dbt_end" {
+  template = file("${path.module}/dbt_end.sql")
+  vars = {
+    monitoring_dataset = var.monitoring_dataset
+  }
+}
+
+# Create dbt_end materialized view
+resource "google_bigquery_table" "dbt_end" {
+  project             = var.project_id
+  dataset_id          = var.monitoring_dataset
+  friendly_name       = "dbt_end"
+  table_id            = "dbt_end"
+  description         = "DBT end stage extraction"
+  deletion_protection = false
+
+  materialized_view {
+    query = data.template_file.dbt_end.rendered
+  }
+
+  depends_on = [
+    google_bigquery_table.dbt_log_table
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      encryption_configuration
+    ]
+  }
+}
+
+
+data "template_file" "dbt_dashboard" {
+  template = file("${path.module}/dbt_dashboard.sql")
+  vars = {
+    project_id         = var.project_id
+    monitoring_dataset = var.monitoring_dataset
+    airflow_url        = var.airflow_url
+    docs_bucket        = var.docs_bucket
+    src_url            = var.src_url
+  }
+}
+
+# Create dbt_dashboard view (for dashboards!)
+resource "google_bigquery_table" "dbt_dashboard" {
+  project             = var.project_id
+  dataset_id          = var.monitoring_dataset
+  friendly_name       = "dbt_dashboard"
+  table_id            = "dbt_dashboard"
+  description         = "DBT dashboard"
+  deletion_protection = false
+
+  view {
+    query          = data.template_file.dbt_dashboard.rendered
+    use_legacy_sql = false
+  }
+
+  depends_on = [
+    google_bigquery_table.dbt_start,
+    google_bigquery_table.dbt_end
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      encryption_configuration
+    ]
+  }
+}
+

--- a/common_components/monitoring/module/outputs.tf
+++ b/common_components/monitoring/module/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 The Reg Reporting Blueprint Authors
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project="PROJECT_ID"
-bq_datasets=[
-  "regrep_source", 
-  "regrep"
-]
-region="REGION"
-bq_location="BQ_LOCATION"
-gcs_location="GCS_LOCATION"
-gcr_hostname="GCR_HOSTNAME"
-enable_composer=true
+

--- a/common_components/monitoring/module/variables.tf
+++ b/common_components/monitoring/module/variables.tf
@@ -1,0 +1,39 @@
+# Copyright 2023 The Reg Reporting Blueprint Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+variable "project_id" {
+  description = "The project ID to for dbt_log monitoring dataset"
+}
+
+variable "bq_location" {
+  description = "The location of monitoring dataset"
+}
+
+variable "airflow_url" {
+  description = "The base URL for airflow (embedded into dashboard tables)"
+}
+
+variable "docs_bucket" {
+  description = "The bucket name storing the generated documentation (embedded into dashboard tables)"
+}
+
+variable "src_url" {
+  description = "The source URL for any source code references (embedded into dashboard tables)"
+}
+
+variable "monitoring_dataset" {
+  description = "The dataset name for monitoring dbt_log"
+  default = "monitoring"
+}

--- a/common_components/orchestration/infrastructure/main.tf
+++ b/common_components/orchestration/infrastructure/main.tf
@@ -84,3 +84,14 @@ module "composer_reg_reporting" {
   env_name          = "reg-runner"
   gcs_ingest_bucket = module.gcs_buckets.bucket.name
 }
+
+# DBT log monitoring
+module "dbt_log_monitoring" {
+  source = "../../monitoring/module"
+
+  project_id        = module.project_services.project_id
+  bq_location       = var.bq_location
+  airflow_url       = module.composer_reg_reporting.airflow_uri
+  src_url           = var.src_url
+  docs_bucket       = module.gcs_buckets.names_list[2]
+}

--- a/common_components/orchestration/infrastructure/variables.tf
+++ b/common_components/orchestration/infrastructure/variables.tf
@@ -35,8 +35,14 @@ variable "bq_datasets" {
   description = "The BQ datasets to create"
 }
 
+variable "src_url" {
+  description = "Source URL for dbt_dashboard (embedded into dashboards)"
+  default     = "https://github.com/GoogleCloudPlatform/reg-reporting-blueprint/tree"
+}
+
 variable "enable_composer" {
   description = "Whether to build composer environment or not"
-  default = false
+  default     = true
 }
+
 


### PR DESCRIPTION
Create a new monitoring terraform module that -
- Creates a new dataset for monitoring
- Initializes the dbt_log table
- Creates two materialized views (dbt_start, dbt_end) and a view (dbt_dashboard) that can power Looker Studio or other dashboards

This also changes the default to create composer when standing up the environment.